### PR TITLE
fix: add dependency libffi-dev whose absence breaks docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.2-apache
 RUN apt update
-RUN apt install -y python3-dev graphviz-dev graphviz python3 python3-pip python3-igraph gcc g++ cron unzip libtool autoconf automake flex bison
+RUN apt install -y python3-dev graphviz-dev graphviz python3 python3-pip python3-igraph gcc g++ cron unzip libtool autoconf automake flex bison libffi-dev
 RUN pip3 install pygraphviz cairocffi
 WORKDIR /var/www/html
 RUN rm -rf *


### PR DESCRIPTION
I encountered a docker build failure caused by missing header file ffi.h, which is fixed by this PR by installing `libffi-dev`.

```
STEP 1/16: FROM php:7.2-apache
STEP 2/16: RUN apt update
--> Using cache a531aebeca661f79bd6f4cbb4d60b173bd3282c50a0e6691d9f79462e11ee7a9
--> a531aebeca6
STEP 3/16: RUN apt install -y python3-dev graphviz-dev graphviz python3 python3-pip python3-igraph gcc g++ cron unzip libtool autoconf automake flex bison
--> Using cache b50dce1a6de97c9b97fc2ba82576812e73432b3f1ace0fa2b8d11757a7ec4699
--> b50dce1a6de
STEP 4/16: RUN pip3 install pygraphviz cairocffi
Collecting pygraphviz
  Downloading https://files.pythonhosted.org/packages/3a/d6/2c56f09ee83dbebb62c40487e4c972135661b9984fec9b30b77fb497090c/pygraphviz-1.7.zip (118kB)
Collecting cairocffi
  Downloading https://files.pythonhosted.org/packages/8b/d2/137b346d64f0d6428a90f60b51a06706592a86b74fd21ff66c853537cb9b/cairocffi-1.3.0.tar.gz (88kB)
    Complete output from command python setup.py egg_info:
    Package libffi was not found in the pkg-config search path.
    Perhaps you should add the directory containing `libffi.pc'
    to the PKG_CONFIG_PATH environment variable
    No package 'libffi' found
    Package libffi was not found in the pkg-config search path.
    Perhaps you should add the directory containing `libffi.pc'
    to the PKG_CONFIG_PATH environment variable
    No package 'libffi' found
    Package libffi was not found in the pkg-config search path.
    Perhaps you should add the directory containing `libffi.pc'
    to the PKG_CONFIG_PATH environment variable
    No package 'libffi' found
    Package libffi was not found in the pkg-config search path.
    Perhaps you should add the directory containing `libffi.pc'
    to the PKG_CONFIG_PATH environment variable
    No package 'libffi' found
    Package libffi was not found in the pkg-config search path.
    Perhaps you should add the directory containing `libffi.pc'
    to the PKG_CONFIG_PATH environment variable
    No package 'libffi' found
    c/_cffi_backend.c:15:10: fatal error: ffi.h: No such file or directory
     #include <ffi.h>
              ^~~~~~~
    compilation terminated.
    Traceback (most recent call last):
      File "/usr/lib/python3.7/distutils/unixccompiler.py", line 118, in _compile
        extra_postargs)
      File "/usr/lib/python3.7/distutils/ccompiler.py", line 909, in spawn
        spawn(cmd, dry_run=self.dry_run)
      File "/usr/lib/python3.7/distutils/spawn.py", line 36, in spawn
        _spawn_posix(cmd, search_path, dry_run=dry_run)
      File "/usr/lib/python3.7/distutils/spawn.py", line 159, in _spawn_posix
        % (cmd, exit_status))
    distutils.errors.DistutilsExecError: command 'x86_64-linux-gnu-gcc' failed with exit status 1

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/usr/lib/python3.7/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/usr/lib/python3.7/distutils/dist.py", line 966, in run_commands
        self.run_command(cmd)
      File "/usr/lib/python3.7/distutils/dist.py", line 985, in run_command
        cmd_obj.run()
      File "/usr/lib/python3/dist-packages/setuptools/command/bdist_egg.py", line 172, in run
        cmd = self.call_command('install_lib', warn_dir=0)
      File "/usr/lib/python3/dist-packages/setuptools/command/bdist_egg.py", line 158, in call_command
        self.run_command(cmdname)
      File "/usr/lib/python3.7/distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/usr/lib/python3.7/distutils/dist.py", line 985, in run_command
        cmd_obj.run()
      File "/usr/lib/python3/dist-packages/setuptools/command/install_lib.py", line 24, in run
        self.build()
      File "/usr/lib/python3.7/distutils/command/install_lib.py", line 109, in build
        self.run_command('build_ext')
      File "/usr/lib/python3.7/distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/usr/lib/python3.7/distutils/dist.py", line 985, in run_command
        cmd_obj.run()
      File "/usr/lib/python3/dist-packages/setuptools/command/build_ext.py", line 78, in run
        _build_ext.run(self)
      File "/usr/lib/python3.7/distutils/command/build_ext.py", line 340, in run
        self.build_extensions()
      File "/usr/lib/python3.7/distutils/command/build_ext.py", line 449, in build_extensions
        self._build_extensions_serial()
      File "/usr/lib/python3.7/distutils/command/build_ext.py", line 474, in _build_extensions_serial
        self.build_extension(ext)
      File "/usr/lib/python3/dist-packages/setuptools/command/build_ext.py", line 199, in build_extension
        _build_ext.build_extension(self, ext)
      File "/usr/lib/python3.7/distutils/command/build_ext.py", line 534, in build_extension
        depends=ext.depends)
      File "/usr/lib/python3.7/distutils/ccompiler.py", line 574, in compile
        self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
      File "/usr/lib/python3.7/distutils/unixccompiler.py", line 120, in _compile
        raise CompileError(msg)
    distutils.errors.CompileError: command 'x86_64-linux-gnu-gcc' failed with exit status 1

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 154, in save_modules
        yield saved
      File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 195, in setup_context
        yield
      File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 250, in run_setup
        _execfile(setup_script, ns)
      File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 45, in _execfile
        exec(code, globals, locals)
      File "/tmp/easy_install-9cyi8vqm/cffi-1.15.0/setup.py", line 236, in <module>
      File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 145, in setup
        return distutils.core.setup(**attrs)
      File "/usr/lib/python3.7/distutils/core.py", line 163, in setup
        raise SystemExit("error: " + str(msg))
    SystemExit: error: command 'x86_64-linux-gnu-gcc' failed with exit status 1

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/usr/lib/python3/dist-packages/setuptools/command/easy_install.py", line 1169, in run_setup
        run_setup(setup_script, args)
      File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 253, in run_setup
        raise
      File "/usr/lib/python3.7/contextlib.py", line 130, in __exit__
        self.gen.throw(type, value, traceback)
      File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 195, in setup_context
        yield
      File "/usr/lib/python3.7/contextlib.py", line 130, in __exit__
        self.gen.throw(type, value, traceback)
      File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 166, in save_modules
        saved_exc.resume()
      File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 141, in resume
        six.reraise(type, exc, self._tb)
      File "/usr/lib/python3/dist-packages/setuptools/_vendor/six.py", line 685, in reraise
        raise value.with_traceback(tb)
      File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 154, in save_modules
        yield saved
      File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 195, in setup_context
        yield
      File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 250, in run_setup
        _execfile(setup_script, ns)
      File "/usr/lib/python3/dist-packages/setuptools/sandbox.py", line 45, in _execfile
        exec(code, globals, locals)
      File "/tmp/easy_install-9cyi8vqm/cffi-1.15.0/setup.py", line 236, in <module>
      File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 145, in setup
        return distutils.core.setup(**attrs)
      File "/usr/lib/python3.7/distutils/core.py", line 163, in setup
        raise SystemExit("error: " + str(msg))
    SystemExit: error: command 'x86_64-linux-gnu-gcc' failed with exit status 1

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-vkhz3cvz/cairocffi/setup.py", line 13, in <module>
        'cairocffi/ffi_build.py:ffi_pixbuf']
      File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 144, in setup
        _install_setup_requires(attrs)
      File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 139, in _install_setup_requires
        dist.fetch_build_eggs(dist.setup_requires)
      File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 724, in fetch_build_eggs
        replace_conflicting=True,
      File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 782, in resolve
        replace_conflicting=replace_conflicting
      File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 1065, in best_match
        return self.obtain(req, installer)
      File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 1077, in obtain
        return installer(requirement)
      File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 791, in fetch_build_egg
        return cmd.easy_install(req)
      File "/usr/lib/python3/dist-packages/setuptools/command/easy_install.py", line 704, in easy_install
        return self.install_item(spec, dist.location, tmpdir, deps)
      File "/usr/lib/python3/dist-packages/setuptools/command/easy_install.py", line 730, in install_item
        dists = self.install_eggs(spec, download, tmpdir)
      File "/usr/lib/python3/dist-packages/setuptools/command/easy_install.py", line 915, in install_eggs
        return self.build_and_install(setup_script, setup_base)
      File "/usr/lib/python3/dist-packages/setuptools/command/easy_install.py", line 1183, in build_and_install
        self.run_setup(setup_script, setup_base, args)
      File "/usr/lib/python3/dist-packages/setuptools/command/easy_install.py", line 1171, in run_setup
        raise DistutilsError("Setup script exited with %s" % (v.args[0],))
    distutils.errors.DistutilsError: Setup script exited with error: command 'x86_64-linux-gnu-gcc' failed with exit status 1

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-vkhz3cvz/cairocffi/
Error: error building at STEP "RUN pip3 install pygraphviz cairocffi": error while running runtime: exit status 1
```